### PR TITLE
Fix the broken GitHub link in the footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ footer-links:
   email:
   facebook:
   flickr:
-  github: https://gregofgreg5.github.io/
+  github: gregofgreg5
   instagram:
   linkedin:
   pinterest:


### PR DESCRIPTION
The GitHub link in the footer of your blog is broken, pointing to `https://github.com/https://gregofgreg5.github.io/`. The `_config.yml` file expects only your GitHub username in this field.